### PR TITLE
Various "swap" calculation fixes/upgrades

### DIFF
--- a/client/src/components/Behodler/Swap/TradingBox3/index.tsx
+++ b/client/src/components/Behodler/Swap/TradingBox3/index.tsx
@@ -225,16 +225,25 @@ export default function () {
     useEffect(() => {
         if (independentFieldState === 'dormant') {
             const independentFieldNumericValue = parseFloat(independentField.newValue);
-            let updating = !Number.isNaN(independentFieldNumericValue) && independentFieldNumericValue > 0;
-            if (independentField.target === 'FROM') {
-                updating = updating && independentField.newValue !== inputValue
-                setInputValue(independentField.newValue)
-                setOutputValue(updating ? 'calculating...' : '')
-            } else {
-                updating = updating && independentField.newValue !== outputValue
-                setInputValue(updating ? 'calculating...' : '')
-                setOutputValue(independentField.newValue)
-            }
+            const independentFieldContainsOnlyDigitsAndDot = /^[\d\.]+$/g.test(independentField.newValue);
+            const isEmptyIndependentFieldInput = independentField.newValue === ''
+            const isValidIndependentFieldInput = isEmptyIndependentFieldInput || (
+                !Number.isNaN(independentFieldNumericValue)
+                && independentFieldNumericValue > 0
+                && independentFieldContainsOnlyDigitsAndDot
+            )
+            const independentFieldTargetIsFrom = independentField.target === 'FROM'
+
+            const updating = independentFieldTargetIsFrom
+                ? isValidIndependentFieldInput && independentField.newValue !== inputValue
+                : isValidIndependentFieldInput && independentField.newValue !== outputValue
+
+            const outputMessage = (!isEmptyIndependentFieldInput && updating && 'calculating...')
+                || (!isValidIndependentFieldInput && 'invalid input')
+                || ''
+
+            setInputValue(independentFieldTargetIsFrom ? independentField.newValue : outputMessage)
+            setOutputValue(independentFieldTargetIsFrom ? outputMessage : independentField.newValue)
 
             if (swapState !== SwapState.IMPOSSIBLE)
                 setSwapState(SwapState.IMPOSSIBLE)

--- a/client/src/components/Behodler/Swap/TradingBox3/index.tsx
+++ b/client/src/components/Behodler/Swap/TradingBox3/index.tsx
@@ -426,10 +426,7 @@ export default function () {
                     options.gas = gas;
                     const txResult = await contract[method](valueInWei)
                         .send(options, hashBack)
-                        .catch(err => {
-                            console.log(`${contract}.${method} failed`, err)
-                            reject(err)
-                        })
+                        .catch(reject)
                     resolve(txResult)
                 })
         })
@@ -449,14 +446,20 @@ export default function () {
             const redeemContract = isOutputEth ? pyroWethProxy : pyroToken
             const options = minting && isInputEth ? ethOptions : primaryOptions
 
-            if (minting) {
-                await mintOrRedeem(mintContract, 'mint', options, inputValWei, mintHashBack)
-            } else {
-                await mintOrRedeem(redeemContract, 'redeem', options, inputValWei, redeemHashBack)
-            }
+            try {
+                if (minting) {
+                    await mintOrRedeem(mintContract, 'mint', options, inputValWei, mintHashBack)
+                } else {
+                    await mintOrRedeem(redeemContract, 'redeem', options, inputValWei, redeemHashBack)
+                }
 
-            setInputValue('')
-            setOutputValue('')
+                setSwapState(SwapState.IMPOSSIBLE)
+                // setIndependentFieldState('dormant');
+                updateIndependentFromField('')
+                updateIndependentToField('')
+            } catch (e) {
+                console.error(e);
+            }
         }
         setSwapClicked(false)
     }, [swapClicked])

--- a/client/src/components/Behodler/Swap/TradingBox3/index.tsx
+++ b/client/src/components/Behodler/Swap/TradingBox3/index.tsx
@@ -454,7 +454,6 @@ export default function () {
                 }
 
                 setSwapState(SwapState.IMPOSSIBLE)
-                // setIndependentFieldState('dormant');
                 updateIndependentFromField('')
                 updateIndependentToField('')
             } catch (e) {

--- a/client/src/components/Behodler/Swap/TradingBox3/index.tsx
+++ b/client/src/components/Behodler/Swap/TradingBox3/index.tsx
@@ -224,7 +224,8 @@ export default function () {
 
     useEffect(() => {
         if (independentFieldState === 'dormant') {
-            let updating = !isNaN(parseFloat(independentField.newValue))
+            const independentFieldNumericValue = parseFloat(independentField.newValue);
+            let updating = !Number.isNaN(independentFieldNumericValue) && independentFieldNumericValue > 0;
             if (independentField.target === 'FROM') {
                 updating = updating && independentField.newValue !== inputValue
                 setInputValue(independentField.newValue)

--- a/client/src/components/Behodler/Swap/TradingBox3/index.tsx
+++ b/client/src/components/Behodler/Swap/TradingBox3/index.tsx
@@ -690,13 +690,13 @@ export default function () {
 
     const greySwap = inputEnabled && (swapState === SwapState.DISABLED || swapState === SwapState.IMPOSSIBLE) || swapping
     const setNewMenuInputAddress = (address: string) => {
-        setInputValue("")
-        setOutputValue("")
+        updateIndependentFromField('')
+        updateIndependentToField('')
         setInputAddress(address)
     }
     const setNewMenuOutputAddress = (address: string) => {
-        setInputValue("")
-        setOutputValue("")
+        updateIndependentFromField('')
+        updateIndependentToField('')
         setOutputAddress(address)
     }
     const staticLogo = Logos.filter(l => l.name === 'Pyrotoken')[0]


### PR DESCRIPTION
* enabled calculating mint/redeem output value for input values exceeding user balances
* disallowed using negative and zero values as a base for calculating the dependent field value
* fixed swap state not fully resetting after a tx completes (mint/redeem button remained active and clicking it without changing any values caused the app to crash)
* fixed inability to swap anything if a user rejects a tx
* fixed redeem rate sometimes not being displayed in cases where it should be visible (this was caused by the inputs not being properly reset when the selected token changed)
* assured that dependent field value is updated only when the independent field input is valid (only positive numbers are allowed), the `invalid input` message is displayed otherwise